### PR TITLE
Bundler 1.17.3 was installed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,4 +266,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
Steps to make heroku pass: 
1. gem install bundler -v 1.17.3
2. bundle _1.17.3_ install
3. git commit -am "Bundler 1.17.3 was installed"
4. git push 
Look at the slack for links to the steps.
